### PR TITLE
Small adjustments based on a code review.

### DIFF
--- a/woocommerce-gateway-payex-payment.php
+++ b/woocommerce-gateway-payex-payment.php
@@ -90,7 +90,7 @@ class WC_Payex_Payment {
 	 */
 	public function plugin_action_links( $links ) {
 		$plugin_links = array(
-			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=checkout&section=wc_gateway_payex_payment' ) ) . '">' . __( 'PayEx Settings', 'woocommerce-gateway-payex-payment' ) . '</a>'
+			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=checkout&section=payex' ) ) . '">' . __( 'Settings', 'woocommerce-gateway-payex-payment' ) . '</a>'
 		);
 
 		return array_merge( $plugin_links, $links );


### PR DESCRIPTION
Hi there.

While doing a code review for WooCommerce, I came across a small bug where the settings link on the "Plugins" screen wasn't directing to the correct settings URL.

I adjusted this, and then set the text to be more generic as well.
