### PR TITLE
Check if array key exists before retrieving current gateway.

### DIFF
--- a/woocommerce-gateway-payex-payment.php
+++ b/woocommerce-gateway-payex-payment.php
@@ -404,10 +404,10 @@ class WC_Payex_Payment {
 		}
 
 		$current         = WC()->session->get( 'chosen_payment_method', $default );
-		$current_gateway = $available_gateways[ $current ];
+		$current_gateway = array_key_exists( $current, $available_gateways ) ? $available_gateways[ $current ] : null;
 
 		// Fee feature in Invoice and Factoring modules
-		if ( ! in_array( $current_gateway->id, array( 'payex_invoice', 'payex_factoring' ) ) ) {
+		if ( ! $current_gateway || ! in_array( $current_gateway->id, array( 'payex_invoice', 'payex_factoring' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
If variable $current at line 406 is null or empty an Undefined index notice is given at line 407. I suggest checking that the key exists.